### PR TITLE
Remove default task

### DIFF
--- a/web-starter/index.js
+++ b/web-starter/index.js
@@ -91,8 +91,6 @@ module.exports = generators.Base.extend({
       this.options.addDevDependency('grunt', '^0.4.5');
       this.options.addDevDependency('include-all', '^0.1.6');
       this.options.addDevDependency('load-grunt-tasks', '^3.2.0');
-      this.options.addDevDependency('grunt-simple-watch', '^0.1.3');
-      this.options.addDevDependency('grunt-contrib-watch', '^1.0.0');
       this.options.addDevDependency('grunt-concurrent', '^2.3.1');
 
       var concurrent = getGruntTask('concurrent');
@@ -104,16 +102,6 @@ module.exports = generators.Base.extend({
       }));
 
       concurrent.loadNpmTasks('grunt-concurrent');
-
-      registerTask('default', [{
-        task: 'build',
-        priority: 50,
-      }]);
-
-      registerTask('default', [{
-        task: 'concurrent:watch',
-        priority: 99,
-      }]);
     },
   },
   writing: {


### PR DESCRIPTION
In order to allow other generators (notably the new React generator) to deploy their own default tasks, this removes the default task we currently ship. I left the definitions for the `concurrent:watch` task in, however, due to the fact that it needed to access the `watchTasks` variable.